### PR TITLE
Implement two-column ECG layout

### DIFF
--- a/codes/ecg-image-generator/config.yaml
+++ b/codes/ecg-image-generator/config.yaml
@@ -1,6 +1,10 @@
 paper_len: 10.0
 abs_lead_step: 10
+# Lead groupings used when plotting with four columns
+# (original 4x3 layout)
 format_4_by_3: [["I", "II", "III"], ["aVR", "aVL", "aVF", "AVR", "AVL", "AVF"], ["V1", "V2", "V3"], ["V4", "V5", "V6"]]
-leadNames_12: ["III", 'aVF', 'V3', 'V6', 'II', 'aVL', 'V2', 'V5', 'I', 'aVR', 'V1', 'V4']
+# Default lead order when plotting 12‑lead ECGs
+# Arranged for two columns with six rows
+leadNames_12: ["I", 'V1', 'II', 'V2', 'III', 'V3', 'aVR', 'V4', 'aVL', 'V5', 'aVF', 'V6']
 tickLength: 8 
 tickSize_step: 0.002 

--- a/codes/ecg-image-generator/ecg_plot.py
+++ b/codes/ecg-image-generator/ecg_plot.py
@@ -218,8 +218,10 @@ def ecg_plot(
     dc_offset = 0
     if(show_dc_pulse):
         dc_offset = sample_rate*standard_values['dc_offset_length']*step
-    #Iterate through each lead in lead_index array.
-    y_offset = (row_height/2)
+    #Iterate through each lead in lead_index array. Randomise top margin so that
+    #the complete ECG grid can start at slightly different vertical offsets
+    top_rand = random.uniform(0, row_height/2)
+    y_offset = (row_height/2) + top_rand
     x_offset = 0
 
     leads_ds = []

--- a/codes/ecg-image-generator/extract_leads.py
+++ b/codes/ecg-image-generator/extract_leads.py
@@ -59,7 +59,8 @@ def get_paper_ecg(input_file,header_file,output_directory, seed, add_dc_pulse,ad
         else:
             full_mode = full_mode
         if(columns==-1):
-            columns = 4
+            # use two columns for twelve-lead ECGs
+            columns = 2
     else:
         gen_m = len(full_leads)
         columns = 4


### PR DESCRIPTION
## Summary
- reorder 12-lead plotting order for 2-column layout
- default to two columns for 12-lead data
- randomise top margin when drawing ECG grid
- document the original 4×3 format and new 2-column order

## Testing
- `python -m py_compile codes/ecg-image-generator/extract_leads.py codes/ecg-image-generator/ecg_plot.py`
- `flake8 codes/ecg-image-generator/extract_leads.py codes/ecg-image-generator/ecg_plot.py` *(fails: style violations)*

------
https://chatgpt.com/codex/tasks/task_e_686cc52d73c48324a89ba05b1427d462